### PR TITLE
opencv is Moved Permanently to opencv.org

### DIFF
--- a/_templates/sidebar_links.html
+++ b/_templates/sidebar_links.html
@@ -13,7 +13,7 @@
 <div class="well sidebar-box">
     <ul class="nav nav-list">
         <li><a class="reference external"
-                href="http://opencv.willowgarage.com">OpenCV</a></li>
+                href="http://opencv.org">OpenCV</a></li>
         <li><a class="reference external"
                 href="http://scikit-learn.org">Scikit-learn</a></li>
         <li><a class="reference external"


### PR DESCRIPTION
Not critical, but should be fixed.

Thanks.
