### PR TITLE
Fix Jumpiness of header.

### DIFF
--- a/themes/scikit-image/static/css/custom.css
+++ b/themes/scikit-image/static/css/custom.css
@@ -84,8 +84,9 @@ h6 {
 
 .headerlink {
     margin-left: 10px;
-    color: #ddd;
-    display: none;
+    color: white; /* fallback */
+    color: rgba(221, 221, 221, 0);
+    display: inline;
 }
 h1:hover .headerlink,
 h2:hover .headerlink,
@@ -93,7 +94,7 @@ h3:hover .headerlink,
 h4:hover .headerlink,
 h5:hover .headerlink,
 h6:hover .headerlink {
-    display: inline;
+    color: #ddd;
 }
 .headerlink:hover {
     color: #CE5C00;


### PR DESCRIPTION
The .headerlink change of display on hover can triger a header reflow on
specific length.

-- 

![jumpy](https://cloud.githubusercontent.com/assets/335567/12693365/b286659c-c6bc-11e5-8ef9-c00af0edc174.gif)

Here: http://scikit-image.org/docs/dev/user_guide/transforming_image_data.html


