### PR TITLE
Fix `sidebar_versions` for Chrome

### DIFF
--- a/_templates/sidebar_versions.html
+++ b/_templates/sidebar_versions.html
@@ -1,5 +1,5 @@
 <script type="text/javascript">
- $.getJSON('http://pypi.python.org/pypi/scikit-image/json?callback=?',
+ $.getJSON('http://pypi.python.org/pypi/scikit-image/json',
            function(data) {
              var month_names = ["January", "February", "March", "April", "May", "June",
                                 "July", "August", "September", "October", "November", "December"];


### PR DESCRIPTION
Tries to address https://github.com/scikit-image/scikit-image/issues/2066 .
This is Google Chrome/Chromium-specific issue (Firefox shows everything fine) and the fix should be checked against it.

UPD: see https://stackoverflow.com/questions/24528211/refused-to-execute-script-from-because-its-mime-type-application-json-is/24528549#24528549 for the details.