### PR TITLE
Change release announcement dates to ISO 8601

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -79,13 +79,13 @@ visit our `gallery </docs/dev/auto_examples>`__.
 Announcements
 -------------
 
-- **Release!** Version 0.12.0 06/03/2016
-- **Release!** Version 0.11.0 04/03/2015
-- **Release!** Version 0.10.0 27/05/2014
+- **Release!** Version 0.12.0 2016-03-06
+- **Release!** Version 0.11.0 2015-03-04
+- **Release!** Version 0.10.0 2014-05-27
 - Pre-print of the scikit-image paper: `https://peerj.com/preprints/336/ <https://peerj.com/preprints/336/>`_
-- **Release!** Version 0.9.0 19/10/2013
-- **Release!** Version 0.8.0 04/03/2013
-- **Release!** Version 0.7.0 30/09/2012
+- **Release!** Version 0.9.0 2013-10-19
+- **Release!** Version 0.8.0 2013-03-04
+- **Release!** Version 0.7.0 2012-09-30
 - **EuroSciPy Sprint**, Belgium, August 2012
 - **SciPy 2012 Sprint**, Austin, July 2012
 


### PR DESCRIPTION
As scikit is an international and scientific project the international / scientific standard for dates should be used.