### PR TITLE
Specify conda-forge channel for conda install docs

### DIFF
--- a/download.rst
+++ b/download.rst
@@ -20,7 +20,7 @@ For Conda-based distributions (Anaconda, Miniconda), execute:
 
 ::
 
-	conda install scikit-image
+	conda install -c conda-forge scikit-image
 	
 
 Linux and OSX


### PR DESCRIPTION
Following the conda install instructions here currently gives you scikit-image 0.13.1 from the default channel, instead of 0.14 from conda-forge (which is the latest stable release). I suggest we explicitly specify using the conda-forge channel here.
Closes issue https://github.com/scikit-image/scikit-image-web/issues/48