### PR TITLE
Various tweaks to front page layout.

### DIFF
--- a/_templates/sidebar_links.html
+++ b/_templates/sidebar_links.html
@@ -1,5 +1,3 @@
-<div style="padding-top: 0.8em;"></div>
-
 <div class="well sidebar-box">
     <ul class="nav nav-list">
         <li><a class="reference external"
@@ -22,3 +20,7 @@
     </ul>
 </div>
 
+<div style="text-align: center;" width="100%">
+  <iframe src="http://ghbtns.com/github-btn.html?user=scikit-image&repo=scikit-image&type=watch&count=true"
+    allowtransparency="true" frameborder="0" scrolling="0" width="110" display="inline-block" height="20"></iframe>
+</div>

--- a/_templates/sidebar_versions.html
+++ b/_templates/sidebar_versions.html
@@ -44,13 +44,4 @@
     <strong>Development</strong>
     <p id="dev-version">pre-x.y.z</p>
     <a class="btn btn-small" href="https://github.com/scikit-image/scikit-image#installation-from-source"><i class="icon-download"></i> Download</a>
-
 </div>
-
-
-<div style="text-align: center;" width="100%">
-  <iframe src="http://ghbtns.com/github-btn.html?user=scikit-image&repo=scikit-image&type=watch&count=true"
-    allowtransparency="true" frameborder="0" scrolling="0" width="110" display="inline-block" height="20"></iframe>
-</div>
-
-<div class="clearfix"></div>

--- a/index.rst
+++ b/index.rst
@@ -87,11 +87,3 @@ visit our `gallery </docs/dev/auto_examples>`__.
          :class: coins-sample span6
 
 You can read more in our `user guide </docs/dev/user_guide>`__. 
-
-
-Developers
-----------
-
-- `Pull requests <https://github.com/scikit-image/scikit-image/pulls>`__
-- `Bug reports <https://github.com/scikit-image/scikit-image/issues>`__
-- `Ohloh summary <http://ohloh.net/p/scikit-image>`__

--- a/themes/scikit-image/static/css/custom.css
+++ b/themes/scikit-image/static/css/custom.css
@@ -275,8 +275,8 @@ p.admonition-title {
 }
 
 .sidebar-subtitle {
-  font-size: small;
-  color: slateblue;
+  font-size: 0.8em;
+  color: black;
   font-style: italic;
   float: right;
 }


### PR DESCRIPTION
- Make size of sidebox descrpitions relative
- Move GitHub star button down
- Remove developer section at bottom of main section