### PR TITLE
Add team gallery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ _build
 gh-pages
 *#
 *.pyc
-
+*~
+\.#*

--- a/Makefile
+++ b/Makefile
@@ -55,3 +55,7 @@ site: html
 # Copy changes to the repo from which they are served
 gh-pages: site
 	python _scripts/gh-pages.py
+
+team:
+	python tools/team_list.py > team.rst
+

--- a/_static/custom.css
+++ b/_static/custom.css
@@ -4,6 +4,7 @@
     margin: 0.5rem;
     width: 7rem;
     height: 70px;
+    text-align: center;
 }
 
 .team-member-photo img {
@@ -12,9 +13,9 @@
 }
 
 .team-member-name {
-    display: none;
+    font-weight: bold;
 }
 
 .team-member-handle {
-    font-weight: bold;
+    display: none;
 }

--- a/_static/custom.css
+++ b/_static/custom.css
@@ -8,16 +8,16 @@
 }
 
 .team-member-photo {
+    display: block;
 }
 
 .team-member-photo img {
     width: 60px;
     border-radius: 50%;
+    margin-bottom: 0.5rem;
 }
 
 .team-member-name {
-    display: block;
-    margin-top: 0.5rem;
     font-weight: bold;
 }
 

--- a/_static/custom.css
+++ b/_static/custom.css
@@ -1,10 +1,13 @@
 .team-member {
     display: inline-block;
     padding: 1rem;
-    margin: 0.5rem;
+    margin: 0.25rem;
     width: 7rem;
-    height: 70px;
     text-align: center;
+    vertical-align: top;
+}
+
+.team-member-photo {
 }
 
 .team-member-photo img {
@@ -13,6 +16,8 @@
 }
 
 .team-member-name {
+    display: block;
+    margin-top: 0.5rem;
     font-weight: bold;
 }
 

--- a/_static/custom.css
+++ b/_static/custom.css
@@ -1,0 +1,20 @@
+.team-member {
+    display: inline-block;
+    padding: 1rem;
+    margin: 0.5rem;
+    width: 7rem;
+    height: 70px;
+}
+
+.team-member-photo img {
+    width: 60px;
+    border-radius: 50%;
+}
+
+.team-member-name {
+    display: none;
+}
+
+.team-member-handle {
+    font-weight: bold;
+}

--- a/conf.py
+++ b/conf.py
@@ -174,3 +174,6 @@ html_show_sourcelink = False
 
 # If nonempty, this is the file name suffix for HTML files (e.g. ".xhtml").
 #html_file_suffix = ''
+
+def setup(app):
+    app.add_css_file("custom.css")

--- a/index.rst
+++ b/index.rst
@@ -88,3 +88,5 @@ visit our `gallery </docs/dev/auto_examples>`__.
          :class: coins-sample span6
 
 You can read more in our `user guide </docs/stable/user_guide.html>`__.
+
+.. include:: team.rst

--- a/team.rst
+++ b/team.rst
@@ -10,10 +10,16 @@ is guided by the following core team:
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars0.githubusercontent.com/u/134307?u=c3083d33a74e974bc69ff3477f6f72bff2126a6b&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/ahojnnes" class="team-member-name">Johannes Schönberger</a>
+     <a href="https://github.com/ahojnnes" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars0.githubusercontent.com/u/134307?u=c3083d33a74e974bc69ff3477f6f72bff2126a6b&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @ahojnnes"
+           />
+        </div>
+        Johannes Schönberger
+     </a>
      <div class="team-member-handle">@ahojnnes</div>
    </div>
 
@@ -21,10 +27,16 @@ is guided by the following core team:
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars1.githubusercontent.com/u/5776022?u=7677a4391774e25b0c0d5c946021a8ab7a1ee519&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/alexdesiqueira" class="team-member-name">Alexandre de Siqueira</a>
+     <a href="https://github.com/alexdesiqueira" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars1.githubusercontent.com/u/5776022?u=7677a4391774e25b0c0d5c946021a8ab7a1ee519&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @alexdesiqueira"
+           />
+        </div>
+        Alexandre de Siqueira
+     </a>
      <div class="team-member-handle">@alexdesiqueira</div>
    </div>
 
@@ -32,10 +44,16 @@ is guided by the following core team:
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars2.githubusercontent.com/u/449558?u=1fae3e7888b9d2812333812f80e91ead9fbfdd3e&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/amueller" class="team-member-name">Andreas Mueller</a>
+     <a href="https://github.com/amueller" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars2.githubusercontent.com/u/449558?u=1fae3e7888b9d2812333812f80e91ead9fbfdd3e&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @amueller"
+           />
+        </div>
+        Andreas Mueller
+     </a>
      <div class="team-member-handle">@amueller</div>
    </div>
 
@@ -43,10 +61,16 @@ is guided by the following core team:
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars3.githubusercontent.com/u/263366?v=4&s=40"/>
-     </div>
-     <a href="https://github.com/emmanuelle" class="team-member-name">Emmanuelle Gouillart</a>
+     <a href="https://github.com/emmanuelle" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars3.githubusercontent.com/u/263366?v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @emmanuelle"
+           />
+        </div>
+        Emmanuelle Gouillart
+     </a>
      <div class="team-member-handle">@emmanuelle</div>
    </div>
 
@@ -54,10 +78,16 @@ is guided by the following core team:
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars2.githubusercontent.com/u/6528957?u=2a7658d9dbc4af127f9d90003462e37de4f73fba&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/grlee77" class="team-member-name">Gregory R. Lee</a>
+     <a href="https://github.com/grlee77" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars2.githubusercontent.com/u/6528957?u=2a7658d9dbc4af127f9d90003462e37de4f73fba&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @grlee77"
+           />
+        </div>
+        Gregory R. Lee
+     </a>
      <div class="team-member-handle">@grlee77</div>
    </div>
 
@@ -65,10 +95,16 @@ is guided by the following core team:
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars2.githubusercontent.com/u/90008?u=19cf915f2609e5b272a4144d8a2840cc6e51f28a&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/hmaarrfk" class="team-member-name">Mark Harfouche</a>
+     <a href="https://github.com/hmaarrfk" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars2.githubusercontent.com/u/90008?u=19cf915f2609e5b272a4144d8a2840cc6e51f28a&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @hmaarrfk"
+           />
+        </div>
+        Mark Harfouche
+     </a>
      <div class="team-member-handle">@hmaarrfk</div>
    </div>
 
@@ -76,10 +112,16 @@ is guided by the following core team:
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars0.githubusercontent.com/u/2184487?u=09e9b57497b6f07a61ee788d722fa9e6988f5c17&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/JDWarner" class="team-member-name">Josh Warner</a>
+     <a href="https://github.com/JDWarner" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars0.githubusercontent.com/u/2184487?u=09e9b57497b6f07a61ee788d722fa9e6988f5c17&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @JDWarner"
+           />
+        </div>
+        Josh Warner
+     </a>
      <div class="team-member-handle">@JDWarner</div>
    </div>
 
@@ -87,10 +129,16 @@ is guided by the following core team:
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars3.githubusercontent.com/u/492549?v=4&s=40"/>
-     </div>
-     <a href="https://github.com/jni" class="team-member-name">Juan Nunez-Iglesias</a>
+     <a href="https://github.com/jni" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars3.githubusercontent.com/u/492549?v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @jni"
+           />
+        </div>
+        Juan Nunez-Iglesias
+     </a>
      <div class="team-member-handle">@jni</div>
    </div>
 
@@ -98,10 +146,16 @@ is guided by the following core team:
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars0.githubusercontent.com/u/20140352?u=aa80243f7c2da2341ac944d70a33daef0c369aed&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/lagru" class="team-member-name">Lars Grüter</a>
+     <a href="https://github.com/lagru" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars0.githubusercontent.com/u/20140352?u=aa80243f7c2da2341ac944d70a33daef0c369aed&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @lagru"
+           />
+        </div>
+        Lars Grüter
+     </a>
      <div class="team-member-handle">@lagru</div>
    </div>
 
@@ -109,10 +163,16 @@ is guided by the following core team:
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars2.githubusercontent.com/u/3438227?u=dd1bcfe9172643955985de8ecdf7ba0627725557&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/rfezzani" class="team-member-name">Riadh Fezzani</a>
+     <a href="https://github.com/rfezzani" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars2.githubusercontent.com/u/3438227?u=dd1bcfe9172643955985de8ecdf7ba0627725557&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @rfezzani"
+           />
+        </div>
+        Riadh Fezzani
+     </a>
      <div class="team-member-handle">@rfezzani</div>
    </div>
 
@@ -120,10 +180,16 @@ is guided by the following core team:
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars3.githubusercontent.com/u/335370?u=b9359e95f23c1864c804ba22f41bcf540951b20e&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/sciunto" class="team-member-name">François Boulogne</a>
+     <a href="https://github.com/sciunto" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars3.githubusercontent.com/u/335370?u=b9359e95f23c1864c804ba22f41bcf540951b20e&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @sciunto"
+           />
+        </div>
+        François Boulogne
+     </a>
      <div class="team-member-handle">@sciunto</div>
    </div>
 
@@ -131,10 +197,16 @@ is guided by the following core team:
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars2.githubusercontent.com/u/1315589?u=05d88a102b0ab695b824525ea208c0a7e561c2c2&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/soupault" class="team-member-name">Egor Panfilov</a>
+     <a href="https://github.com/soupault" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars0.githubusercontent.com/u/1315589?u=4ef9afb42ea75a6a9a6f6f9afcca0a4114b0c0b5&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @soupault"
+           />
+        </div>
+        Egor Panfilov
+     </a>
      <div class="team-member-handle">@soupault</div>
    </div>
 
@@ -142,10 +214,16 @@ is guided by the following core team:
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars3.githubusercontent.com/u/45071?u=c779b5e06448fbc638bc987cdfe305c7f9a7175e&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/stefanv" class="team-member-name">Stefan van der Walt</a>
+     <a href="https://github.com/stefanv" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars3.githubusercontent.com/u/45071?u=c779b5e06448fbc638bc987cdfe305c7f9a7175e&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @stefanv"
+           />
+        </div>
+        Stefan van der Walt
+     </a>
      <div class="team-member-handle">@stefanv</div>
    </div>
 
@@ -161,10 +239,16 @@ We thank these previously-active core developers for their contributions to scik
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars3.githubusercontent.com/u/2096628?u=2a4822ff8dc6b4f1162c58716d48fdfac08c8601&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/blink1073" class="team-member-name">Steven Silvester</a>
+     <a href="https://github.com/blink1073" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars3.githubusercontent.com/u/2096628?u=2a4822ff8dc6b4f1162c58716d48fdfac08c8601&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @blink1073"
+           />
+        </div>
+        Steven Silvester
+     </a>
      <div class="team-member-handle">@blink1073</div>
    </div>
 
@@ -172,10 +256,16 @@ We thank these previously-active core developers for their contributions to scik
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars1.githubusercontent.com/u/133031?v=4&s=40"/>
-     </div>
-     <a href="https://github.com/tonysyu" class="team-member-name">Tony S Yu</a>
+     <a href="https://github.com/tonysyu" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars1.githubusercontent.com/u/133031?v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @tonysyu"
+           />
+        </div>
+        Tony S Yu
+     </a>
      <div class="team-member-handle">@tonysyu</div>
    </div>
 
@@ -183,10 +273,16 @@ We thank these previously-active core developers for their contributions to scik
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="https://avatars3.githubusercontent.com/u/174217?u=7d678fe9b727d884498e757eeb7e510483e1f811&v=4&s=40"/>
-     </div>
-     <a href="https://github.com/zpincus" class="team-member-name">Zachary Pincus</a>
+     <a href="https://github.com/zpincus" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="https://avatars3.githubusercontent.com/u/174217?u=7d678fe9b727d884498e757eeb7e510483e1f811&v=4&s=40"
+             loading="lazy"
+             alt="Avatar picture of @zpincus"
+           />
+        </div>
+        Zachary Pincus
+     </a>
      <div class="team-member-handle">@zpincus</div>
    </div>
 

--- a/team.rst
+++ b/team.rst
@@ -110,7 +110,7 @@ is guided by the following core team:
 
    <div class="team-member">
      <div class="team-member-photo">
-       <img src="https://avatars2.githubusercontent.com/u/3438227?v=4&s=40"/>
+       <img src="https://avatars2.githubusercontent.com/u/3438227?u=dd1bcfe9172643955985de8ecdf7ba0627725557&v=4&s=40"/>
      </div>
      <a href="https://github.com/rfezzani" class="team-member-name">Riadh Fezzani</a>
      <div class="team-member-handle">@rfezzani</div>
@@ -150,6 +150,25 @@ is guided by the following core team:
    </div>
 
 
+
+Emeritus Developers
+-------------------
+
+We thank these previously-active core developers for their contributions to scikit-image.
+
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars3.githubusercontent.com/u/2096628?u=2a4822ff8dc6b4f1162c58716d48fdfac08c8601&v=4&s=40"/>
+     </div>
+     <a href="https://github.com/blink1073" class="team-member-name">Steven Silvester</a>
+     <div class="team-member-handle">@blink1073</div>
+   </div>
+
+
 .. raw:: html
 
    <div class="team-member">
@@ -170,12 +189,4 @@ is guided by the following core team:
      <a href="https://github.com/zpincus" class="team-member-name">Zachary Pincus</a>
      <div class="team-member-handle">@zpincus</div>
    </div>
-
-
-
-Emeritus Developers
--------------------
-
-We thank these previously-active core developers for their contributions to scikit-image.
-
 

--- a/team.rst
+++ b/team.rst
@@ -13,8 +13,8 @@ is guided by the following core team:
      <div class="team-member-photo">
        <img src="https://avatars0.githubusercontent.com/u/134307?u=c3083d33a74e974bc69ff3477f6f72bff2126a6b&v=4&s=40"/>
      </div>
-     <div class="team-member-name">Johannes Schönberger</div>
-     <a href="https://github.com/ahojnnes" class="team-member-handle">@ahojnnes</a>
+     <a href="https://github.com/ahojnnes" class="team-member-name">Johannes Schönberger</a>
+     <div class="team-member-handle">@ahojnnes</div>
    </div>
 
 
@@ -24,8 +24,8 @@ is guided by the following core team:
      <div class="team-member-photo">
        <img src="https://avatars1.githubusercontent.com/u/5776022?u=7677a4391774e25b0c0d5c946021a8ab7a1ee519&v=4&s=40"/>
      </div>
-     <div class="team-member-name">Alexandre de Siqueira</div>
-     <a href="https://github.com/alexdesiqueira" class="team-member-handle">@alexdesiqueira</a>
+     <a href="https://github.com/alexdesiqueira" class="team-member-name">Alexandre de Siqueira</a>
+     <div class="team-member-handle">@alexdesiqueira</div>
    </div>
 
 
@@ -35,8 +35,8 @@ is guided by the following core team:
      <div class="team-member-photo">
        <img src="https://avatars2.githubusercontent.com/u/449558?u=1fae3e7888b9d2812333812f80e91ead9fbfdd3e&v=4&s=40"/>
      </div>
-     <div class="team-member-name">Andreas Mueller</div>
-     <a href="https://github.com/amueller" class="team-member-handle">@amueller</a>
+     <a href="https://github.com/amueller" class="team-member-name">Andreas Mueller</a>
+     <div class="team-member-handle">@amueller</div>
    </div>
 
 
@@ -46,8 +46,8 @@ is guided by the following core team:
      <div class="team-member-photo">
        <img src="https://avatars3.githubusercontent.com/u/263366?v=4&s=40"/>
      </div>
-     <div class="team-member-name">Emmanuelle Gouillart</div>
-     <a href="https://github.com/emmanuelle" class="team-member-handle">@emmanuelle</a>
+     <a href="https://github.com/emmanuelle" class="team-member-name">Emmanuelle Gouillart</a>
+     <div class="team-member-handle">@emmanuelle</div>
    </div>
 
 
@@ -57,8 +57,8 @@ is guided by the following core team:
      <div class="team-member-photo">
        <img src="https://avatars2.githubusercontent.com/u/6528957?u=2a7658d9dbc4af127f9d90003462e37de4f73fba&v=4&s=40"/>
      </div>
-     <div class="team-member-name">Gregory R. Lee</div>
-     <a href="https://github.com/grlee77" class="team-member-handle">@grlee77</a>
+     <a href="https://github.com/grlee77" class="team-member-name">Gregory R. Lee</a>
+     <div class="team-member-handle">@grlee77</div>
    </div>
 
 
@@ -68,8 +68,8 @@ is guided by the following core team:
      <div class="team-member-photo">
        <img src="https://avatars2.githubusercontent.com/u/90008?u=19cf915f2609e5b272a4144d8a2840cc6e51f28a&v=4&s=40"/>
      </div>
-     <div class="team-member-name">Mark Harfouche</div>
-     <a href="https://github.com/hmaarrfk" class="team-member-handle">@hmaarrfk</a>
+     <a href="https://github.com/hmaarrfk" class="team-member-name">Mark Harfouche</a>
+     <div class="team-member-handle">@hmaarrfk</div>
    </div>
 
 
@@ -79,8 +79,8 @@ is guided by the following core team:
      <div class="team-member-photo">
        <img src="https://avatars0.githubusercontent.com/u/2184487?u=09e9b57497b6f07a61ee788d722fa9e6988f5c17&v=4&s=40"/>
      </div>
-     <div class="team-member-name">Josh Warner</div>
-     <a href="https://github.com/JDWarner" class="team-member-handle">@JDWarner</a>
+     <a href="https://github.com/JDWarner" class="team-member-name">Josh Warner</a>
+     <div class="team-member-handle">@JDWarner</div>
    </div>
 
 
@@ -90,8 +90,8 @@ is guided by the following core team:
      <div class="team-member-photo">
        <img src="https://avatars3.githubusercontent.com/u/492549?v=4&s=40"/>
      </div>
-     <div class="team-member-name">Juan Nunez-Iglesias</div>
-     <a href="https://github.com/jni" class="team-member-handle">@jni</a>
+     <a href="https://github.com/jni" class="team-member-name">Juan Nunez-Iglesias</a>
+     <div class="team-member-handle">@jni</div>
    </div>
 
 
@@ -101,8 +101,8 @@ is guided by the following core team:
      <div class="team-member-photo">
        <img src="https://avatars0.githubusercontent.com/u/20140352?u=aa80243f7c2da2341ac944d70a33daef0c369aed&v=4&s=40"/>
      </div>
-     <div class="team-member-name">Lars Grüter</div>
-     <a href="https://github.com/lagru" class="team-member-handle">@lagru</a>
+     <a href="https://github.com/lagru" class="team-member-name">Lars Grüter</a>
+     <div class="team-member-handle">@lagru</div>
    </div>
 
 
@@ -112,8 +112,8 @@ is guided by the following core team:
      <div class="team-member-photo">
        <img src="https://avatars2.githubusercontent.com/u/3438227?v=4&s=40"/>
      </div>
-     <div class="team-member-name">Riadh Fezzani</div>
-     <a href="https://github.com/rfezzani" class="team-member-handle">@rfezzani</a>
+     <a href="https://github.com/rfezzani" class="team-member-name">Riadh Fezzani</a>
+     <div class="team-member-handle">@rfezzani</div>
    </div>
 
 
@@ -123,8 +123,8 @@ is guided by the following core team:
      <div class="team-member-photo">
        <img src="https://avatars3.githubusercontent.com/u/335370?u=b9359e95f23c1864c804ba22f41bcf540951b20e&v=4&s=40"/>
      </div>
-     <div class="team-member-name">François Boulogne</div>
-     <a href="https://github.com/sciunto" class="team-member-handle">@sciunto</a>
+     <a href="https://github.com/sciunto" class="team-member-name">François Boulogne</a>
+     <div class="team-member-handle">@sciunto</div>
    </div>
 
 
@@ -134,8 +134,8 @@ is guided by the following core team:
      <div class="team-member-photo">
        <img src="https://avatars1.githubusercontent.com/u/1315589?u=925c7a474919699fc03c39a75876dd0abc0fa790&v=4&s=40"/>
      </div>
-     <div class="team-member-name">Egor Panfilov</div>
-     <a href="https://github.com/soupault" class="team-member-handle">@soupault</a>
+     <a href="https://github.com/soupault" class="team-member-name">Egor Panfilov</a>
+     <div class="team-member-handle">@soupault</div>
    </div>
 
 
@@ -145,8 +145,8 @@ is guided by the following core team:
      <div class="team-member-photo">
        <img src="https://avatars3.githubusercontent.com/u/45071?u=c779b5e06448fbc638bc987cdfe305c7f9a7175e&v=4&s=40"/>
      </div>
-     <div class="team-member-name">Stefan van der Walt</div>
-     <a href="https://github.com/stefanv" class="team-member-handle">@stefanv</a>
+     <a href="https://github.com/stefanv" class="team-member-name">Stefan van der Walt</a>
+     <div class="team-member-handle">@stefanv</div>
    </div>
 
 
@@ -156,8 +156,8 @@ is guided by the following core team:
      <div class="team-member-photo">
        <img src="https://avatars1.githubusercontent.com/u/133031?v=4&s=40"/>
      </div>
-     <div class="team-member-name">Tony S Yu</div>
-     <a href="https://github.com/tonysyu" class="team-member-handle">@tonysyu</a>
+     <a href="https://github.com/tonysyu" class="team-member-name">Tony S Yu</a>
+     <div class="team-member-handle">@tonysyu</div>
    </div>
 
 
@@ -167,8 +167,8 @@ is guided by the following core team:
      <div class="team-member-photo">
        <img src="https://avatars3.githubusercontent.com/u/174217?u=7d678fe9b727d884498e757eeb7e510483e1f811&v=4&s=40"/>
      </div>
-     <div class="team-member-name">Zachary Pincus</div>
-     <a href="https://github.com/zpincus" class="team-member-handle">@zpincus</a>
+     <a href="https://github.com/zpincus" class="team-member-name">Zachary Pincus</a>
+     <div class="team-member-handle">@zpincus</div>
    </div>
 
 

--- a/team.rst
+++ b/team.rst
@@ -132,7 +132,7 @@ is guided by the following core team:
 
    <div class="team-member">
      <div class="team-member-photo">
-       <img src="https://avatars1.githubusercontent.com/u/1315589?u=925c7a474919699fc03c39a75876dd0abc0fa790&v=4&s=40"/>
+       <img src="https://avatars2.githubusercontent.com/u/1315589?u=05d88a102b0ab695b824525ea208c0a7e561c2c2&v=4&s=40"/>
      </div>
      <a href="https://github.com/soupault" class="team-member-name">Egor Panfilov</a>
      <div class="team-member-handle">@soupault</div>

--- a/team.rst
+++ b/team.rst
@@ -1,0 +1,181 @@
+
+Our Team
+--------
+
+Along with a large community of contributors, scikit-image development
+is guided by the following core team:
+
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars0.githubusercontent.com/u/134307?u=c3083d33a74e974bc69ff3477f6f72bff2126a6b&v=4&s=40"/>
+     </div>
+     <div class="team-member-name">Johannes Schönberger</div>
+     <a href="https://github.com/ahojnnes" class="team-member-handle">@ahojnnes</a>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars1.githubusercontent.com/u/5776022?u=7677a4391774e25b0c0d5c946021a8ab7a1ee519&v=4&s=40"/>
+     </div>
+     <div class="team-member-name">Alexandre de Siqueira</div>
+     <a href="https://github.com/alexdesiqueira" class="team-member-handle">@alexdesiqueira</a>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars2.githubusercontent.com/u/449558?u=1fae3e7888b9d2812333812f80e91ead9fbfdd3e&v=4&s=40"/>
+     </div>
+     <div class="team-member-name">Andreas Mueller</div>
+     <a href="https://github.com/amueller" class="team-member-handle">@amueller</a>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars3.githubusercontent.com/u/263366?v=4&s=40"/>
+     </div>
+     <div class="team-member-name">Emmanuelle Gouillart</div>
+     <a href="https://github.com/emmanuelle" class="team-member-handle">@emmanuelle</a>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars2.githubusercontent.com/u/6528957?u=2a7658d9dbc4af127f9d90003462e37de4f73fba&v=4&s=40"/>
+     </div>
+     <div class="team-member-name">Gregory R. Lee</div>
+     <a href="https://github.com/grlee77" class="team-member-handle">@grlee77</a>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars2.githubusercontent.com/u/90008?u=19cf915f2609e5b272a4144d8a2840cc6e51f28a&v=4&s=40"/>
+     </div>
+     <div class="team-member-name">Mark Harfouche</div>
+     <a href="https://github.com/hmaarrfk" class="team-member-handle">@hmaarrfk</a>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars0.githubusercontent.com/u/2184487?u=09e9b57497b6f07a61ee788d722fa9e6988f5c17&v=4&s=40"/>
+     </div>
+     <div class="team-member-name">Josh Warner</div>
+     <a href="https://github.com/JDWarner" class="team-member-handle">@JDWarner</a>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars3.githubusercontent.com/u/492549?v=4&s=40"/>
+     </div>
+     <div class="team-member-name">Juan Nunez-Iglesias</div>
+     <a href="https://github.com/jni" class="team-member-handle">@jni</a>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars0.githubusercontent.com/u/20140352?u=aa80243f7c2da2341ac944d70a33daef0c369aed&v=4&s=40"/>
+     </div>
+     <div class="team-member-name">Lars Grüter</div>
+     <a href="https://github.com/lagru" class="team-member-handle">@lagru</a>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars2.githubusercontent.com/u/3438227?v=4&s=40"/>
+     </div>
+     <div class="team-member-name">Riadh Fezzani</div>
+     <a href="https://github.com/rfezzani" class="team-member-handle">@rfezzani</a>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars3.githubusercontent.com/u/335370?u=b9359e95f23c1864c804ba22f41bcf540951b20e&v=4&s=40"/>
+     </div>
+     <div class="team-member-name">François Boulogne</div>
+     <a href="https://github.com/sciunto" class="team-member-handle">@sciunto</a>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars1.githubusercontent.com/u/1315589?u=925c7a474919699fc03c39a75876dd0abc0fa790&v=4&s=40"/>
+     </div>
+     <div class="team-member-name">Egor Panfilov</div>
+     <a href="https://github.com/soupault" class="team-member-handle">@soupault</a>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars3.githubusercontent.com/u/45071?u=c779b5e06448fbc638bc987cdfe305c7f9a7175e&v=4&s=40"/>
+     </div>
+     <div class="team-member-name">Stefan van der Walt</div>
+     <a href="https://github.com/stefanv" class="team-member-handle">@stefanv</a>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars1.githubusercontent.com/u/133031?v=4&s=40"/>
+     </div>
+     <div class="team-member-name">Tony S Yu</div>
+     <a href="https://github.com/tonysyu" class="team-member-handle">@tonysyu</a>
+   </div>
+
+
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="https://avatars3.githubusercontent.com/u/174217?u=7d678fe9b727d884498e757eeb7e510483e1f811&v=4&s=40"/>
+     </div>
+     <div class="team-member-name">Zachary Pincus</div>
+     <a href="https://github.com/zpincus" class="team-member-handle">@zpincus</a>
+   </div>
+
+
+
+Emeritus Developers
+-------------------
+
+We thank these previously-active core developers for their contributions to scikit-image.
+
+

--- a/tools/team_list.py
+++ b/tools/team_list.py
@@ -40,8 +40,8 @@ def render_team(team):
      <div class="team-member-photo">
        <img src="{member['avatar_url']}&s=40"/>
      </div>
-     <div class="team-member-name">{profile['name']}</div>
-     <a href="https://github.com/{member['login']}" class="team-member-handle">@{member['login']}</a>
+     <a href="https://github.com/{member['login']}" class="team-member-name">{profile['name']}</a>
+     <div class="team-member-handle">@{member['login']}</div>
    </div>
 """)
 

--- a/tools/team_list.py
+++ b/tools/team_list.py
@@ -40,7 +40,7 @@ def render_team(team):
      <div class="team-member-photo">
        <img src="{member['avatar_url']}&s=40"/>
      </div>
-     <a href="https://github.com/{member['login']}" class="team-member-name">{profile['name']}</a>
+     <a href="https://github.com/{member['login']}" class="team-member-name">{profile['name'] if profile['name'] else '@' + profile['login']}</a>
      <div class="team-member-handle">@{member['login']}</div>
    </div>
 """)

--- a/tools/team_list.py
+++ b/tools/team_list.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import requests
+
+
+project = 'scikit-image'
+team = 'core'
+emeritus_team = 'emeritus'
+team_url = f'https://api.github.com/orgs/{project}/teams/{team}/members'
+emeritus_team_url = f'https://api.github.com/orgs/{project}/teams/{emeritus_team}/members'
+
+
+token = os.environ.get('GH_TOKEN', None)
+if token is None:
+    print("No token found.  Please export a GH_TOKEN with permissions "
+          "to read team members.")
+    sys.exit(-1)
+
+
+def api(url):
+    return requests.get(url=url,
+                        headers={'Authorization': f'token {token}'}).json()
+
+
+resp = api(team_url)
+team = sorted(resp, key=lambda user: user['login'].lower())
+
+resp = api(emeritus_team_url)
+emeritus_team = sorted(resp, key=lambda user: user['login'].lower())
+
+
+def render_team(team):
+    for member in team:
+        profile = api(member['url'])
+
+        print(f"""
+.. raw:: html
+
+   <div class="team-member">
+     <div class="team-member-photo">
+       <img src="{member['avatar_url']}&s=40"/>
+     </div>
+     <div class="team-member-name">{profile['name']}</div>
+     <a href="https://github.com/{member['login']}" class="team-member-handle">@{member['login']}</a>
+   </div>
+""")
+
+
+print("""
+Our Team
+--------
+
+Along with a large community of contributors, scikit-image development
+is guided by the following core team:
+
+""")
+
+render_team(team)
+
+print("""
+
+Emeritus Developers
+-------------------
+
+We thank these previously-active core developers for their contributions to scikit-image.
+
+""")
+
+render_team(emeritus_team)

--- a/tools/team_list.py
+++ b/tools/team_list.py
@@ -37,10 +37,16 @@ def render_team(team):
 .. raw:: html
 
    <div class="team-member">
-     <div class="team-member-photo">
-       <img src="{member['avatar_url']}&s=40"/>
-     </div>
-     <a href="https://github.com/{member['login']}" class="team-member-name">{profile['name'] if profile['name'] else '@' + profile['login']}</a>
+     <a href="https://github.com/{member['login']}" class="team-member-name">
+        <div class="team-member-photo">
+           <img
+             src="{member['avatar_url']}&s=40"
+             loading="lazy"
+             alt="Avatar picture of @{profile['login']}"
+           />
+        </div>
+        {profile['name'] if profile['name'] else '@' + profile['login']}
+     </a>
      <div class="team-member-handle">@{member['login']}</div>
    </div>
 """)


### PR DESCRIPTION
Left to be done:

- [x] Move emeritus core developers to `emeritus` group on GitHub
- [x] Re-render `teams.rst` using the provided `tools/team_list.py`

<img src="https://user-images.githubusercontent.com/45071/88726333-5f671980-d0e2-11ea-81fc-bd7ef0b4da98.png" width="600px"/>