### PR TITLE
Standardize tab names in homepage.

### DIFF
--- a/_templates/navbar.html
+++ b/_templates/navbar.html
@@ -1,9 +1,8 @@
-<li><a href="/docs/stable/install.html">Download</a></li>
+<li><a href="/docs/stable/install.html">Installation</a></li>
 <li><a href="/docs/stable/auto_examples">Gallery</a></li>
 
 <li><a href="/docs/stable">Documentation</a></li>
-<li><a href="{{ pathto('community_guidelines') }}">Community
-        Guidelines</a></li>
+<li><a href="{{ pathto('community_guidelines') }}">Community</a></li>
 <li><a href="https://github.com/scikit-image/scikit-image">
     <img src="_static/GitHub-Mark-32px.png" style="height: 15px; width: 15px;
                                                    display: inline; float: none;

--- a/community_guidelines.rst
+++ b/community_guidelines.rst
@@ -13,7 +13,7 @@ acknowledging our own mistakes, and generous in our praise.
 If you ever feel like you are not being treated as well as you should, please
 get in touch with one of the project leads (our email addresses are available
 through our GitHub profiles).  We are committed to making this community a
-safe and welcome space.
+safe and welcoming space.
 
 You can learn more about contributing to scikit-image at
 https://scikit-image.org/docs/stable/contribute.html.


### PR DESCRIPTION
Hi,

Helping out a new contributor brought me back to the issue resolved by #70 (tab names change as we click, say, "Download" from the homepage). So today I'm resurrecting this PR using a branch from a clone (instead of not my own fork). Let's see...